### PR TITLE
Fixed space in dir

### DIFF
--- a/git_modify.py
+++ b/git_modify.py
@@ -8,7 +8,7 @@ import git
 
 class RepoModifier(object):
     edit_command = """\
-    cd \"{path}\"
+    cd "{path}"
     rm -rf "$(git rev-parse --git-dir)/refs/original/"
 
     git filter-branch --env-filter \\

--- a/git_modify.py
+++ b/git_modify.py
@@ -8,7 +8,7 @@ import git
 
 class RepoModifier(object):
     edit_command = """\
-    cd {path}
+    cd \"{path}\"
     rm -rf "$(git rev-parse --git-dir)/refs/original/"
 
     git filter-branch --env-filter \\


### PR DESCRIPTION
```bash
127.0.0.1 - - [18/Jun/2019 14:00:55] "POST /get_command HTTP/1.1" 200 -
modify_time.sh: line 1: cd: too many arguments
Rewrite de26bf35db8393eb77e70ea2045cf726ad608fef (5/10) (1 seconds passed, remaining 1 predicted)
WARNING: Ref 'refs/heads/master' is unchanged
```
Something went wrong from `cd`, causing a modification failure.
I executed the command one by one, and then found the problem.
```bash
$ cd C:\\Users\\Jingtang Zhang\\Desktop\\zxy-birthday-gift
bash: cd: too many arguments
```
I had a space in my user name of Windows OS, thus having a space in directory. 😧
So I think making the directory path as a whole string seems better. 😅 And it works.